### PR TITLE
Adjust plugin discovery to be independent of module names

### DIFF
--- a/author/__init__.py
+++ b/author/__init__.py
@@ -49,3 +49,5 @@ from processor import (
     ProcessorSchemas,
     supported_schemas
 )
+
+from plugins import Plugins

--- a/author/job.py
+++ b/author/job.py
@@ -45,7 +45,7 @@ from ..constants import (
     INHERIT_ENVIRONMENT,
     ENVIRONMENT_RESOLVER
 )
-from ..plugins import Plugins
+from .plugins import Plugins
 from ..query.command import get_local_state
 
 

--- a/author/plugins.py
+++ b/author/plugins.py
@@ -51,12 +51,6 @@ class Singleton(object):
 
 class Plugins(Singleton):
 
-    MODULE_NAMES = ["tasks",
-                    "processors"]
-
-    # do we ever need to support more than that *.pyd??
-    MODULE_EXTENSIONS = [".py"]
-
     def __init__(self):
         if not Singleton._initialized or not ENABLE_PLUGIN_CACHE:
             Singleton._initialized = True
@@ -79,9 +73,9 @@ class Plugins(Singleton):
         modules = []
         for name, path in [(os.path.splitext(_f)[0], os.path.join(searchpath, _f))
                                             for _f in os.listdir(searchpath)
-                                            if os.path.splitext(_f)[1] in self.MODULE_EXTENSIONS
-                                            and os.path.splitext(_f)[0] in self.MODULE_NAMES]:
-            modulename = "farm_submitter_{}_{}".format(name, index)
+                                            if os.path.splitext(_f)[1] == ".py"
+                                            and os.path.splitext(_f)[0] != "__init__"]:
+            modulename = "jobtronaut_{}_{}".format(name, index)
             try:
                 modules.append(imp.load_source(modulename, path))
                 _LOG.debug("Sourced {0} as module named {1}".format(path, modulename))

--- a/author/task.py
+++ b/author/task.py
@@ -57,7 +57,7 @@ from ..constants import (
     EXECUTABLE_RESOLVER,
     LOGGING_NAMESPACE
 )
-from ..plugins import Plugins
+from .plugins import Plugins
 from .command import Command
 from .job import (
     Job,

--- a/cmdline.py
+++ b/cmdline.py
@@ -28,7 +28,7 @@ import argparse
 import ast
 import logging
 
-from .plugins import Plugins
+from .author.plugins import Plugins
 from .author import Job
 
 from .constants import LOGGING_NAMESPACE

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -21,5 +21,3 @@
 #  LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY    #
 #  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                                 #
 # ######################################################################################################################
-
-from plugins import Plugins


### PR DESCRIPTION
The plugins module has also been moved to the author namespace to prevent namespace issues and plugin load errors.