### PR TITLE
mayascript.mel prints full error stack

### DIFF
--- a/author/scripts/mayascript.mel
+++ b/author/scripts/mayascript.mel
@@ -28,4 +28,4 @@
 // of executing python code directy as we would need within the current implementation of Task.script() within
 // the farmsubmission API.
 
-python( "import sys;exec(sys.argv[-1])" );
+python( "import sys, traceback\ntry:\n    exec(sys.argv[-1])\nexcept Exception:\n    traceback.print_exc(); raise;" );


### PR DESCRIPTION
To assist debugging the full error context when using mayascript.mel
as the entry point for maya-based jobtronaut processes.
Previously, only the very last error line would be logged.